### PR TITLE
ALL-2097 Add server name mapper to HttpsRedirect

### DIFF
--- a/src/test/java/com/bazaarvoice/dropwizard/redirect/HttpsRedirectTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/redirect/HttpsRedirectTest.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.dropwizard.redirect;
 
+import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
@@ -13,14 +14,21 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-public class HttpsRedirectTest
-{
+public class HttpsRedirectTest {
     private static final String PUBLIC_IP = "1.2.3.4";
     private static final String LOOPBACK_IP = "127.0.0.1";
     private static final String SITE_LOCAL_IP = "10.100.1.1";
     private static final String LINK_LOCAL_IP = "169.254.0.1";
+    private static final String SOURCE_SERVER = "source-server";
+    private static final String TARGET_SERVER = "target-server";
 
     private final HttpsRedirect redirect = new HttpsRedirect();
+    private final HttpsRedirect redirectMapper = new HttpsRedirect(true, new Function<String, String>() {
+        @Override
+        public String apply(String sourceName) {
+            return SOURCE_SERVER.equals(sourceName) ? TARGET_SERVER : sourceName;
+        }
+    });
 
     @Test
     public void testPublicHttpsUrl() {
@@ -103,6 +111,86 @@ public class HttpsRedirectTest
     }
 
     @Test
+    public void testPublicHttpsRedirectUrl() {
+        HttpServletRequest request = request(PUBLIC_IP, "https://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testLoopbackHttpsRedirectUrl() {
+        HttpServletRequest request = request(LOOPBACK_IP, "https://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testSiteLocalHttpsRedirectUrl() {
+        HttpServletRequest request = request(SITE_LOCAL_IP, "https://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testLinkLocalHttpsRedirectUrl() {
+        HttpServletRequest request = request(LINK_LOCAL_IP, "https://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testPublicHttpRedirectUrl() {
+        HttpServletRequest request = request(PUBLIC_IP, "http://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertEquals("https://target-server/path", url);
+    }
+
+    @Test
+    public void testPublicHttpRedirectUrlWithParameters() {
+        HttpServletRequest request = request(PUBLIC_IP, "http://source-server/path?key=value");
+
+        String url = redirectMapper.getRedirect(request);
+        assertEquals("https://target-server/path?key=value", url);
+    }
+
+    @Test
+    public void testPublicHttpRedirectUrlWithPort() {
+        HttpServletRequest request = request(PUBLIC_IP, "http://source-server:8080/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertEquals("https://target-server/path", url);
+    }
+
+    @Test
+    public void testLoopbackRedirectHttpUrl() {
+        HttpServletRequest request = request(LOOPBACK_IP, "http://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testSiteLocalRedirectHttpUrl() {
+        HttpServletRequest request = request(SITE_LOCAL_IP, "http://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
+    public void testLinkLocalRedirectHttpUrl() {
+        HttpServletRequest request = request(LINK_LOCAL_IP, "http://source-server/path");
+
+        String url = redirectMapper.getRedirect(request);
+        assertNull(url);
+    }
+
+    @Test
     public void testPublicFtpUrl() {
         HttpServletRequest request = request(PUBLIC_IP, "ftp://server/path");
 
@@ -134,8 +222,7 @@ public class HttpsRedirectTest
         assertNull(url);
     }
 
-    private static HttpServletRequest request(String sourceAddress, String url)
-    {
+    private static HttpServletRequest request(String sourceAddress, String url) {
         URL parsed;
         try {
             parsed = new URL(url);


### PR DESCRIPTION
Optionally provide ability to map server name to a new name, in addition to HTTPS.
