### PR TITLE
Rename UriRedirect -> PathRedirect and add new UriRedirect functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Just add this maven dependency:
 - For Dropwizard 0.6.2: use version < 0.3.0
 - For Dropwizard 0.7.0: use version >= 0.3.0
 
-To redirect one URI to another URI:
+To redirect one path to another path:
 ```java
 public class MyApplication extends Application<...> {
   // ...
@@ -21,7 +21,7 @@ public class MyApplication extends Application<...> {
   @Override
   public void initialize(Bootstrap<?> bootstrap) {
     bootstrap.addBundle(new RedirectBundle(
-      new UriRedirect("/old", "/new")
+      new PathRedirect("/old", "/new")
     ));
   }
 
@@ -29,7 +29,7 @@ public class MyApplication extends Application<...> {
 }
 ```
 
-To redirect many URIs at once:
+To redirect many paths at once:
 ```java
 public class MyApplication extends Application<...> {
   // ...
@@ -37,7 +37,7 @@ public class MyApplication extends Application<...> {
   @Override
   public void initialize(Bootstrap<?> bootstrap) {
     bootstrap.addBundle(new RedirectBundle(
-      new UriRedirect(ImmutableMap.<String, String>builder()
+      new PathRedirect(ImmutableMap.<String, String>builder()
         .put("/old1", "/new1")
         .put("/old2", "/new2")
         .build())
@@ -57,6 +57,23 @@ public class MyApplication extends Application<...> {
   public void initialize(Bootstrap<?> bootstrap) {
     bootstrap.addBundle(new RedirectBundle(
       new HttpsRedirect()
+    ));
+  }
+
+  // ...
+}
+```
+
+For more advanced users, there is also a regular expression based redirector that has access to the full URI.  This
+operates in a similar fashion to the mod-rewrite module for Apache:
+```java
+public class MyApplication extends Application<...> {
+  // ...
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+    bootstrap.addBundle(new RedirectBundle(
+      new UriRedirect("(.*)/welcome.html$", "$1/index.html")
     ));
   }
 

--- a/src/main/java/com/bazaarvoice/dropwizard/redirect/PathRedirect.java
+++ b/src/main/java/com/bazaarvoice/dropwizard/redirect/PathRedirect.java
@@ -1,0 +1,57 @@
+package com.bazaarvoice.dropwizard.redirect;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/** Redirects requests coming on a specific source path to a target path. */
+public class PathRedirect implements Redirect {
+    private final Map<String, String> pathMapping;
+    private final boolean keepParameters;
+
+    public PathRedirect(String sourceUri, String targetUri) {
+        this(sourceUri, targetUri, true);
+    }
+
+    public PathRedirect(String sourceUri, String targetUri, boolean keepParameters) {
+        checkNotNull(sourceUri);
+        checkNotNull(targetUri);
+
+        pathMapping = ImmutableMap.of(sourceUri, targetUri);
+        this.keepParameters = keepParameters;
+    }
+
+    public PathRedirect(Map<String, String> uriMap) {
+        this(uriMap, true);
+    }
+
+    public PathRedirect(Map<String, String> uriMap, boolean keepParameters) {
+        checkNotNull(uriMap);
+
+        pathMapping = ImmutableMap.copyOf(uriMap);
+        this.keepParameters = keepParameters;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getRedirect(HttpServletRequest request) {
+        String uri = pathMapping.get(request.getRequestURI());
+        if (uri == null) {
+            return null;
+        }
+
+        StringBuilder redirect = new StringBuilder(uri);
+        if (keepParameters) {
+            String query = request.getQueryString();
+            if (query != null) {
+                redirect.append('?');
+                redirect.append(query);
+            }
+        }
+
+        return redirect.toString();
+    }
+}

--- a/src/test/java/com/bazaarvoice/dropwizard/redirect/PathRedirectTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/redirect/PathRedirectTest.java
@@ -1,0 +1,74 @@
+package com.bazaarvoice.dropwizard.redirect;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.mockito.internal.stubbing.answers.ThrowsException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class PathRedirectTest {
+    private final PathRedirect redirect = new PathRedirect(ImmutableMap.<String, String>builder()
+            .put("/old1", "/new1")
+            .put("/old2", "/new2")
+            .build()
+    );
+
+    @Test
+    public void testMatchingUri() {
+        HttpServletRequest request = request("/old1");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("/new1", uri);
+    }
+
+    @Test
+    public void testMatchingUriWithKeepParameters() {
+        HttpServletRequest request = request("/old1?key=value");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("/new1?key=value", uri);
+    }
+
+    @Test
+    public void testMatchingUriWithoutKeepParameters() {
+        PathRedirect redirect = new PathRedirect("/old1", "/new1", false);
+        HttpServletRequest request = request("/old1?key=value");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("/new1", uri);
+    }
+
+    @Test
+    public void testNonMatchingUri() {
+        HttpServletRequest request = request("/new");
+
+        String uri = redirect.getRedirect(request);
+        assertNull(uri);
+    }
+
+    @Test
+    public void testSubstringUri() {
+        HttpServletRequest request = request("/old100");
+
+        String uri = redirect.getRedirect(request);
+        assertNull(uri);
+    }
+
+    private static HttpServletRequest request(String uri) {
+        int question = uri.indexOf('?');
+        String path = (question == -1) ? uri : uri.substring(0, question);
+        String params = (question == -1) ? null : uri.substring(question + 1);
+
+        // By default have the mock throw an exception when we've forgotten to mock a method that is called.
+        Exception exception = new RuntimeException("Forgot to mock a method");
+        HttpServletRequest request = mock(HttpServletRequest.class, new ThrowsException(exception));
+        doReturn(path).when(request).getRequestURI();
+        doReturn(params).when(request).getQueryString();
+        return request;
+    }
+}

--- a/src/test/java/com/bazaarvoice/dropwizard/redirect/UriRedirectTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/redirect/UriRedirectTest.java
@@ -1,10 +1,13 @@
 package com.bazaarvoice.dropwizard.redirect;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -12,63 +15,77 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 public class UriRedirectTest {
-    private final UriRedirect redirect = new UriRedirect(ImmutableMap.<String, String>builder()
-            .put("/old1", "/new1")
-            .put("/old2", "/new2")
-            .build()
-    );
-
     @Test
-    public void testMatchingUri() {
-        HttpServletRequest request = request("/old1");
+    public void testMatchingPath() {
+        UriRedirect redirect = new UriRedirect("http://server/old", "http://server/new");
+        HttpServletRequest request = request("http://server/old");
 
         String uri = redirect.getRedirect(request);
-        assertEquals("/new1", uri);
+        assertEquals("http://server/new", uri);
     }
 
     @Test
-    public void testMatchingUriWithKeepParameters() {
-        HttpServletRequest request = request("/old1?key=value");
-
-        String uri = redirect.getRedirect(request);
-        assertEquals("/new1?key=value", uri);
-    }
-
-    @Test
-    public void testMatchingUriWithoutKeepParameters() {
-        UriRedirect redirect = new UriRedirect("/old1", "/new1", false);
-        HttpServletRequest request = request("/old1?key=value");
-
-        String uri = redirect.getRedirect(request);
-        assertEquals("/new1", uri);
-    }
-
-    @Test
-    public void testNonMatchingUri() {
-        HttpServletRequest request = request("/new");
+    public void testNonMatchingPath() {
+        UriRedirect redirect = new UriRedirect("http://server/old", "http://server/new");
+        HttpServletRequest request = request("http://server/path");
 
         String uri = redirect.getRedirect(request);
         assertNull(uri);
     }
 
     @Test
-    public void testSubstringUri() {
-        HttpServletRequest request = request("/old100");
+    public void testChangeScheme() {
+        UriRedirect redirect = new UriRedirect("http://(.*)", "https://$1");
+        HttpServletRequest request = request("http://server/path");
 
         String uri = redirect.getRedirect(request);
-        assertNull(uri);
+        assertEquals("https://server/path", uri);
+    }
+
+    @Test
+    public void testChangePath() {
+        UriRedirect redirect = new UriRedirect("(.*)/welcome.html", "$1/index.html");
+        HttpServletRequest request = request("http://server/product/welcome.html");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("http://server/product/index.html", uri);
+    }
+
+    @Test
+    public void testKeepParameters() {
+        UriRedirect redirect = new UriRedirect(".*\\?(.*)", "http://new-server/new-path?$1");
+        HttpServletRequest request = request("http://server/path?param1=1&param2=2");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("http://new-server/new-path?param1=1&param2=2", uri);
+    }
+
+    @Test
+    public void testMultiplePatterns() {
+        UriRedirect redirect = new UriRedirect(ImmutableMap.<String, String>builder()
+                .put("http://server1/path1", "http://server1/path2")
+                .put("http://server2/path1", "http://server2/path2")
+                .build());
+        HttpServletRequest request = request("http://server2/path1");
+
+        String uri = redirect.getRedirect(request);
+        assertEquals("http://server2/path2", uri);
     }
 
     private static HttpServletRequest request(String uri) {
-        int question = uri.indexOf('?');
-        String path = (question == -1) ? uri : uri.substring(0, question);
-        String params = (question == -1) ? null : uri.substring(question + 1);
+        URL url;
+        try {
+            url = new URL(uri);
+        } catch (MalformedURLException e) {
+            throw Throwables.propagate(e);
+        }
 
         // By default have the mock throw an exception when we've forgotten to mock a method that is called.
         Exception exception = new RuntimeException("Forgot to mock a method");
         HttpServletRequest request = mock(HttpServletRequest.class, new ThrowsException(exception));
-        doReturn(path).when(request).getRequestURI();
-        doReturn(params).when(request).getQueryString();
+        doReturn(url.getPath()).when(request).getRequestURI();
+        doReturn(url.getQuery()).when(request).getQueryString();
+        doReturn(new StringBuffer(url.toExternalForm())).when(request).getRequestURL();
         return request;
     }
 }


### PR DESCRIPTION
This is a proposed set of changes to allow one to accomplish a similar effect to #8, but not hardcoding it into the `HttpsRedirect`.

This introduces a generalized redirector that operates in a similar fashion to Apache mod-rewrite.  Users can apply a regular expression match pattern as well as replacement to a complete URI.  With that they can change protocols, ports, hosts, paths, or parameters.  I think that will meet the use case that #8 intended to address and more.
